### PR TITLE
Fix Windows File Locking Issue

### DIFF
--- a/perl-tests/cli_fixing.pl
+++ b/perl-tests/cli_fixing.pl
@@ -24,6 +24,7 @@ sub assert_fix_compare {
   my $before = "test-files/fixes/$dir/before.bib";
   my $expected = "test-files/fixes/$dir/expected.bib";
   my ($a, $after) = tempfile();
+  close $a;
   my $cmd = "perl ./bibcop.pl --fix $before > $after";
   my $stdout = `$cmd`;
   my $exit = $? >> 8;


### PR DESCRIPTION
When running `perl tests.pl` on Windows, I encountered the following error:

```
Процесс не может получить доступ к файлу, так как этот файл занят другим процессом.
```

The following exit code was returned:

```
Exit code is 1 (not zero) for 'perl ./bibcop.pl --fix test-files/fixes/duplicates/before.bib > <temporary file>'
```

I believe this is a system-related issue caused by Windows being unable to write to a temporary file while it is still open.

Now explicitly closes the file handle before using the filename in a subprocess. 
