### PR TITLE
bug(#148): Bibcop complaining about 'e' surname particle

### DIFF
--- a/bibcop.pl
+++ b/bibcop.pl
@@ -150,7 +150,7 @@ sub check_author {
         if ($name =~ /^[A-Z][^.]+$/) {
           next
         }
-        if ($name =~ /^(van|de|der|dos|von)$/) {
+        if ($name =~ /^(van|de|der|dos|von|e)$/) {
           next
         }
         if ($name =~ /^[A-Z]$/) {


### PR DESCRIPTION
Added  `'e'` to the list of allowed lowercase surname particles.

Closes: #148.