### PR TITLE
fix(#156): complain about repeated bib entries

### DIFF
--- a/bibcop.pl
+++ b/bibcop.pl
@@ -1118,9 +1118,17 @@ if (@ARGV+0 eq 0 or exists $args{'--help'} or exists $args{'-?'}) {
   } else {
     debug((@entries+0) . ' entries found in ' . $file);
     my $found = 0;
+    my %seen;
     for my $i (0..(@entries+0 - 1)) {
       my %entry = %{ $entries[$i] };
       debug("Checking $entry{':name'} (no.$i)...");
+      my $name = $entry{':name'};
+      if (defined $name and exists $seen{$name}) {
+        warning("The entry '$name' is seen more than once");
+        $found += 1;
+      } elsif (defined $name) {
+        $seen{$name} = 1;
+      }
       foreach my $err (process_entry(%entry)) {
         warning("$err, in the '$entry{':name'}' entry");
         $found += 1;

--- a/perl-tests/cli.pl
+++ b/perl-tests/cli.pl
@@ -19,6 +19,9 @@ assert_exec('--fix ./test-files/test.bib', 0, qr/\Q{{The TeX Book}}\E/s);
 assert_exec('README.md', 0, qr/\QEach BibTeX entry must start with '@'\E/s);
 assert_exec('--verbose README.md', 0, qr/\Q0 entries found in README.md\E/s);
 
+assert_exec('./test-files/duplicates.bib', 1, qr/\QThe entry 'knuth1974' is seen more than once\E/s);
+assert_exec('--latex ./test-files/duplicates.bib', 0, qr/\Q\PackageWarningNoLine{bibcop}{The entry 'knuth1974' is seen more than once\E/s);
+
 assert_exec('missing-file.bib', 1, qr/\QCannot open file: missing-file.bib\E/s);
 assert_exec('--latex missing-file.bib', 0, qr/\Q\PackageError{bibcop}{Cannot open file: missing-file.bib}{}\E/s);
 assert_exec('--fix', 1, qr/\QFile name must be specified\E/s);

--- a/test-files/duplicates.bib
+++ b/test-files/duplicates.bib
@@ -1,0 +1,20 @@
+% SPDX-FileCopyrightText: Copyright (c) 2022-2026 Yegor Bugayenko
+% SPDX-License-Identifier: MIT
+
+% Two entries share the same citation key, which must be reported.
+
+@book{knuth1974,
+  author = {Knuth, Donald E. and Duane, Bibby},
+  title = {{The TeX Book}},
+  year = {1984},
+  doi = {10.5555/1102013},
+  publisher = {Addison-Wesley Professional},
+}
+
+@book{knuth1974,
+  author = {Knuth, Donald E.},
+  title = {{The TeX Book}},
+  year = {1984},
+  doi = {10.5555/1102013},
+  publisher = {Addison-Wesley},
+}


### PR DESCRIPTION
@yegor256 this closes #156 by teaching `bibcop.pl` to complain when two BibTeX entries share the same citation key.

## What changes

- In the main check loop (non-`--fix` path), I track every `":name"` I have already seen. When a duplicate shows up, I emit `warning("The entry '<name>' is seen more than once")` and count it toward `$found`, so `bibcop` exits with a non-zero status (or emits a `\PackageWarningNoLine` under `--latex`), matching the behavior of every other check.
- The `--fix` path was already deduplicating by name silently (line 1103), so I left it untouched.

## Commits

- `test(#156)`: adds `test-files/duplicates.bib` plus two `assert_exec` calls in `perl-tests/cli.pl` covering both the default and `--latex` modes. Confirmed failing on master before the fix.
- `fix(#156)`: 8-line change in `bibcop.pl` that makes those tests pass.

## Verification

- `perl tests.pl` — all green locally
- `perlcritic --exclude=strict --exclude=require bibcop.pl tests.pl perl-tests/*.pl` — source OK

## CI status

All Perl/lint jobs (`perlcritic`, `xcop`, `typos`, `pdd`, `copyrights`, `reuse`, `yamllint`, `actionlint`, `markdown-lint`) are green. The `l3build` jobs fail at the `zauguin/install-texlive@v4.0.0` step with `tlmgr` exit 1 — the same pre-existing TeX Live 2025 installer failure that is present on `master` (`3f7121c`, `bf01694`, `c59ef9d`, ...) and was also present on the last merged PR #172. It is not triggered by anything in this change; my edits only touch `bibcop.pl` and the Perl tests.
