### PR TITLE
Fix #110: ignore '{ACM}'/'{IEEE}' wrapped in braces inside booktitle

### DIFF
--- a/bibcop.pl
+++ b/bibcop.pl
@@ -246,6 +246,11 @@ sub check_org_in_booktitle {
   my @orgs = qw/ACM IEEE/;
   if (exists($entry{'booktitle'})) {
     my $title = $entry{'booktitle'};
+    # Drop substrings protected by curly brackets (TeX case-preservation),
+    # so '{ACM}' or '{IEEE}' inside the booktitle is treated as part of the
+    # original conference name and does not trigger this warning.
+    $title =~ s/^\{(.+)\}$/$1/;
+    while ($title =~ s/\{[^{}]*\}//g) {};
     foreach my $o (@orgs) {
       if ($title =~ /^.*\Q$o\E.*$/) {
         return "The '$o' organization must not be mentioned in the booktitle, use 'publisher' tag instead"

--- a/perl-tests/checks.pl
+++ b/perl-tests/checks.pl
@@ -168,6 +168,13 @@ check_fails($f, ('title' => 'Story & Story'));
 check_passes($f, ('title' => 'Story \& Story'));
 check_passes($f, ('title' => 'Story {&} Story'));
 
+$f = 'check_org_in_booktitle';
+check_fails($f, ('booktitle' => '{Proceedings of the ACM Symposium on Whatever}'));
+check_fails($f, ('booktitle' => '{Proceedings of the IEEE International Conference}'));
+check_passes($f, ('booktitle' => '{Proceedings of the Joint {ACM}-ISCOPE Conference on Java Grande}'));
+check_passes($f, ('booktitle' => '{Proceedings of the {IEEE} International Workshop on Whatever}'));
+check_passes($f, ('booktitle' => '{Proceedings of the Conference on Programming Languages}'));
+
 sub check_fails {
   my ($f, %entry) = @_;
   no strict 'refs';


### PR DESCRIPTION
@yegor256 this fixes #110.

## What

`check_org_in_booktitle` in `bibcop.pl` was flagging any occurrence of `ACM` or `IEEE` inside a `booktitle`, even when the substring was wrapped in `{...}` for TeX case-preservation. So an entirely legitimate booktitle like

```
booktitle = {{Proceedings of the Joint {ACM}-ISCOPE Conference on Java Grande}}
```

produced `The 'ACM' organization must not be mentioned in the booktitle, use 'publisher' tag instead`.

## How

Before matching `ACM`/`IEEE`, strip the outer wrapping (`{...}`) and any inner `{...}` groups from the booktitle. Anything the user explicitly protected with curly brackets is treated as part of the original conference name and ignored by this check. Raw, unprotected `ACM` or `IEEE` is still reported.

## Tests

Added the first tests for `check_org_in_booktitle` in `perl-tests/checks.pl`:

- `{Proceedings of the ACM Symposium on Whatever}` &rarr; still fails (raw `ACM`)
- `{Proceedings of the IEEE International Conference}` &rarr; still fails (raw `IEEE`)
- `{Proceedings of the Joint {ACM}-ISCOPE Conference on Java Grande}` &rarr; passes
- `{Proceedings of the {IEEE} International Workshop on Whatever}` &rarr; passes
- `{Proceedings of the Conference on Programming Languages}` &rarr; passes

`./tests.pl` is green locally.

## CI

All lint/style/typo/copyright/PDD/perlcritic/actionlint/yamllint/markdown/xcop/reuse jobs are green. The only red job is `l3build (ubuntu-24.04)`, and it fails before my code is even touched: the `zauguin/install-texlive@v4.0.0` step exits non-zero. The same job fails identically on `master` (and has been failing since July 2025, see #174 and the open #170 bumping the action to v4.3) so this PR does not regress CI.