### PR TITLE
#109: allow capitalized minor word after LaTeX opening quote

### DIFF
--- a/bibcop.pl
+++ b/bibcop.pl
@@ -76,7 +76,7 @@ sub check_capitalization {
     if (not exists $tags{$tag}) {
       next;
     }
-    my @ends = qw/ ; ? . --- : ! /;
+    my @ends = qw/ ; ? . --- : ! ` /;
     my $value = $entry{$tag};
     my @words = only_words($value);
     my $pos = 0;

--- a/perl-tests/checks.pl
+++ b/perl-tests/checks.pl
@@ -110,6 +110,10 @@ check_passes($f, ('title' => 'Analysis of {GitHub.com} Users'));
 check_passes($f, ('title' => 'Don\'t Read'));
 check_passes($f, ('title' => 'We\'ve Done It'));
 check_passes($f, ('title' => 'Developer\'s Story'));
+check_passes($f, ('booktitle' => '{Conferences ``On the Move\'\'}'));
+check_passes($f, ('booktitle' => '{Workshop on `On Demand\' Computing}'));
+check_passes($f, ('title' => 'A Study of ``In Context\'\' Learning'));
+check_fails($f, ('title' => '``in Context\'\' Learning'));
 
 $f = 'check_howpublished';
 check_fails($f, ('howpublished' => 'hello'));


### PR DESCRIPTION
@yegor256 — closes #109.

## Summary

In `bibcop.pl`, `check_capitalization` rejected a minor word that immediately followed a LaTeX opening quote. The reproducer from the issue:

```
booktitle = {{Conferences ``On the Move''}}
```

was reported as:

```
All minor words in the booktitle must be lower-cased, while the 4th word 'On' is not
```

even though `On` is the first word of a quoted phrase and capitalizing it is correct title-case.

## Why it happens

`only_words` puts a space around any non-alphanumeric character that is not a backslash or apostrophe, so the backtick characters of the LaTeX opening quote get their own tokens. By the time `check_capitalization` reaches `On`, the preceding token is `` ` `` rather than the previous real word. `` ` `` was not in the `@ends` list of segment-terminating punctuation (`; ? . --- : !`), so the lower-case rule kicked in.

## Fix

Add `` ` `` to `@ends` in `check_capitalization`, treating an opening LaTeX quote the same way as `;`, `?`, `.`, `:`, etc. — a boundary that begins a new segment in which a minor word may be capitalized. The change is one character in `bibcop.pl:79`.

A minor word that is itself lower-cased right after the opening quote (e.g. ` ``in Context'' `) is still flagged, because the existing `exists $minors{$word}` branch then triggers and reports "must be upper-cased, because it follows '`'".

## Tests

Four cases added in `perl-tests/checks.pl`:

- `check_passes` — `{Conferences ``On the Move''}` (the issue reproducer)
- `check_passes` — `` {Workshop on `On Demand' Computing} `` (single-quote variant)
- `check_passes` — ` A Study of ``In Context'' Learning ` (quoted phrase mid-title)
- `check_fails` — ` ``in Context'' Learning ` (lower-case minor word right after the opening quote)

All four fail on master and pass on this branch. Locally `perl tests.pl` is green.

## CI

9 of 11 checks are green (perlcritic, pdd, xcop, copyrights, reuse, actionlint, yamllint, markdown-lint, typos). The two `l3build` jobs are red, but the failure is in the `zauguin/install-texlive@v4.0.0` step before any of my code runs — this is the same pre-existing CI breakage tracked in #174 ("l3build CI build is broken"), and the most recent merged PR (#175) shipped with the same red `l3build` jobs.
