### PR TITLE
Add Architecture section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,64 @@ If you use [pre-commit], simply add this to your config:
         args: []
 ```
 
+## Architecture
+
+The core logic resides in a single [Perl](https://www.perl.org) script,
+  `bibcop.pl`, which parses `.bib` files and runs all checks.
+The [LaTeX](https://www.latex-project.org) package (`bibcop.sty`) is a
+  thin wrapper that invokes this script at compile time via the `\iexec`
+  macro (from [iexec](https://ctan.org/pkg/iexec)), using TeX's
+  `--shell-escape` mechanism, by hooking into `\bibliography` and
+  `\addbibresource`.
+This is the key differentiator from tools like
+  [biblint](https://github.com/Kingsford-Group/biblint) and
+  [biblatex-check](https://github.com/pezmc/biblatex-check), which run
+  only from the command line: bibcop runs automatically during every
+  LaTeX compilation without a separate invocation step.
+
+Check functions follow a naming convention: every Perl subroutine whose
+  name matches `check_*` is auto-discovered at runtime by introspecting
+  the package symbol table inside `process_entry()`.
+Adding a new check requires only a new `sub check_*` function with no
+  registration step, so a defined check can never be silently skipped.
+
+Only six [BibTeX](http://www.bibtex.org) entry types are permitted:
+  `@article`, `@book`, `@incollection`, `@inproceedings`, `@misc`, and
+  `@phdthesis`, each with a fixed allowlist of tags in `%blessed`.
+Tags outside the allowlist are an error.
+This closed-world model is stricter than tools such as
+  [biblatex-check](https://github.com/pezmc/biblatex-check), which
+  tolerate arbitrary or unknown tags.
+
+The [BibTeX](http://www.bibtex.org) parser in `entries()` is a
+  hand-written, character-by-character state machine that depends only
+  on Perl's built-in `POSIX` and `File::Basename` modules.
+[BibTeX::Parser](https://metacpan.org/pod/BibTeX::Parser) and similar
+  [CPAN](https://www.cpan.org) libraries were deliberately avoided so
+  that installing bibcop from [CTAN](https://ctan.org/pkg/bibcop)
+  requires no separate Perl module installation.
+
+The script detects at runtime whether it is invoked as a CLI tool or
+  loaded as a Perl module via `require`, by inspecting `basename($0)`.
+This lets the same file serve both the LaTeX package backend and the
+  standalone command-line interface without any code duplication.
+
+The package source and documentation coexist in a single `.dtx` file
+  following the [DocStrip](https://ctan.org/pkg/docstrip) convention;
+  the `.sty` is extracted by [l3build](https://ctan.org/pkg/l3build)
+  via `bibcop.ins`.
+Tests split into two suites: [l3build](https://ctan.org/pkg/l3build)
+  testfiles cover the LaTeX integration layer, while `perl tests.pl`
+  runs Perl-level unit tests directly.
+
+Beyond reporting, the `--fix` flag activates an auto-correction mode
+  where dedicated `fix_*` subroutines reformat field values: author
+  names, page ranges, capitalization, and
+  [Unicode](https://unicode.org)-to-TeX transliteration.
+This repair capability is absent from both
+  [biblint](https://github.com/Kingsford-Group/biblint) and
+  [biblatex-check](https://github.com/pezmc/biblatex-check).
+
 ## How to Contribute
 
 If you want to contribute yourself, make a fork, then create a branch,


### PR DESCRIPTION
@yegor256, this PR adds an "Architecture" section to README.md.

The section is placed immediately before "How to Contribute" (the second `##` heading before the last one) and covers seven key architectural decisions:

1. **Perl + LaTeX shell-escape coupling** — `bibcop.sty` delegates all work to `bibcop.pl` via `\iexec` at compile time, making bibcop run automatically during LaTeX compilation, unlike CLI-only tools such as [biblint](https://github.com/Kingsford-Group/biblint) or [biblatex-check](https://github.com/pezmc/biblatex-check).

2. **Convention-based check discovery** — `process_entry()` auto-discovers every `check_*` subroutine by introspecting the Perl symbol table; no registration required.

3. **Closed allowlist of entry types and tags** — only six entry types and their explicit tag sets (in `%blessed`) are accepted; anything outside is an error.

4. **Hand-rolled BibTeX state-machine parser** — no CPAN dependencies; depends only on Perls built-in modules, keeping the package self-contained on CTAN.

5. **Dual-mode script** — `basename($0)` detects CLI vs. module context, eliminating code duplication between the LaTeX backend and the CLI.

6. **DocStrip literate programming** — source and docs in one `.dtx` file, extracted by l3build, following standard CTAN convention.

7. **Fix-mode duality** — `--fix` activates per-tag `fix_*` subroutines for auto-correction, absent in competing tools.

All lines in the new section are ≤80 characters; continuation lines are indented by two spaces. `markdownlint` reports no warnings.