### PR TITLE
#136: allow arXiv article metadata

### DIFF
--- a/bibcop.pl
+++ b/bibcop.pl
@@ -18,7 +18,7 @@ my %args = map { $_ => 1 } @ARGV;
 
 # Only these tags are allowed and only these types of entries.
 my %blessed = (
-  'article' => ['doi', 'year', 'title', 'author', 'journal', 'volume', 'number', 'month?', 'pages?'],
+  'article' => ['doi', 'year', 'title', 'author', 'journal', 'volume', 'number', 'month?', 'pages?', 'archiveprefix?', 'eprint?', 'primaryclass?'],
   'inproceedings' => ['doi', 'booktitle', 'title', 'author', 'year', 'pages?', 'month?', 'organization?', 'volume?'],
   'incollection' => ['doi', 'booktitle', 'title', 'author', 'year', 'editor', 'pages?', 'month?', 'volume?', 'publisher?'],
   'book' => ['title', 'author', 'year', 'publisher', 'doi?', 'edition?'],
@@ -47,6 +47,9 @@ sub check_mandatory_tags {
     if (not(exists $entry{$tag})) {
       my $listed = listed_tags(%entry);
       if ($tag eq 'doi' and exists $args{'--no:doi'}) {
+        next;
+      }
+      if ($type eq 'article' and exists $entry{'archiveprefix'} and grep { $_ eq $tag } qw/journal volume number/) {
         next;
       }
       return "A mandatory '$tag' tag for '\@$type' is missing among $listed"
@@ -214,26 +217,33 @@ sub check_wrapping {
 # See https://arxiv.org/help/arxiv_identifier
 sub check_arXiv {
   my (%entry) = @_;
-  if (exists($entry{'archiveprefix'})) {
-    if (not exists $entry{'eprint'}) {
-      return "The 'eprint' is mandatory when 'archiveprefix' is there"
-    }
-    if (not $entry{'eprint'} =~ /^[0-9]{4}\.[0-9]{4,5}(v[0-9]+)?$/) {
-      return "The 'eprint' must have two integers separated by a dot"
-    }
-    my $eprint = $entry{'eprint'};
-    my ($head, $tail) = split(/\./, $eprint);
-    my $year = substr($head, 0, 2);
-    my $month = substr($head, 2);
-    if ($month > 12) {
-      return "The month '$month' of the 'eprint' is wrong, it can't be bigger than 12"
-    }
-    if (not exists $entry{'primaryclass'}) {
-      return "The 'primaryclass' is mandatory when 'archiveprefix' is there"
-    }
-    if (not $entry{'primaryclass'} =~ /^[a-z]{2,}\.[A-Z]{2}$/) {
-      return "The 'primaryclass' must have two parts, like 'cs.PL'"
-    }
+  if (not grep { exists $entry{$_} } qw/archiveprefix eprint primaryclass/) {
+    return;
+  }
+  if (not exists $entry{'archiveprefix'}) {
+    return "The 'archiveprefix' is mandatory when arXiv tags are there"
+  }
+  if (not $entry{'archiveprefix'} eq 'arXiv') {
+    return "The 'archiveprefix' must be 'arXiv'"
+  }
+  if (not exists $entry{'eprint'}) {
+    return "The 'eprint' is mandatory when 'archiveprefix' is there"
+  }
+  if (not $entry{'eprint'} =~ /^[0-9]{4}\.[0-9]{4,5}(v[0-9]+)?$/) {
+    return "The 'eprint' must have two integers separated by a dot"
+  }
+  my $eprint = $entry{'eprint'};
+  my ($head, $tail) = split(/\./, $eprint);
+  my $year = substr($head, 0, 2);
+  my $month = substr($head, 2);
+  if ($month > 12) {
+    return "The month '$month' of the 'eprint' is wrong, it can't be bigger than 12"
+  }
+  if (not exists $entry{'primaryclass'}) {
+    return "The 'primaryclass' is mandatory when 'archiveprefix' is there"
+  }
+  if (not $entry{'primaryclass'} =~ /^[a-z]{2,}\.[A-Z]{2}$/) {
+    return "The 'primaryclass' must have two parts, like 'cs.PL'"
   }
 }
 

--- a/perl-tests/checking.pl
+++ b/perl-tests/checking.pl
@@ -68,6 +68,16 @@ passes((
   'pages' => '22--33'
 ));
 passes((
+  ':type' => 'article',
+  'author' => "Li, Jiawei and Farag{\\'o}, David and Petrov, Christian and Ahmed, Iftekhar",
+  'title' => '{{Optimization Is Better Than Generation: Optimizing Commit Message Leveraging Human-Written Commit Message}}',
+  'year' => '2025',
+  'archiveprefix' => 'arXiv',
+  'eprint' => '2501.09861',
+  'primaryclass' => 'cs.SE',
+  'doi' => '10.48550/arXiv.2501.09861'
+));
+passes((
   ':type' => 'misc',
   'author' => 'Doe, John',
   'title' => '{{The Title}}',

--- a/perl-tests/checks.pl
+++ b/perl-tests/checks.pl
@@ -162,6 +162,8 @@ check_passes($f, ('doi' => '10.1002/(SICI)1096-908X(199701)9:1<47::AID-SMR142>3.
 
 $f = 'check_arXiv';
 check_fails($f, ('archiveprefix' => 'arXiv'));
+check_fails($f, ('eprint' => '2112.13384', 'primaryclass' => 'cs.PL'));
+check_fails($f, ('archiveprefix' => 'Arxiv', 'eprint' => '2112.13384', 'primaryclass' => 'cs.PL'));
 check_fails($f, ('archiveprefix' => 'arXiv', 'eprint' => '2111.13384'));
 check_fails($f, ('archiveprefix' => 'arXiv', 'eprint' => 'abc', 'primaryclass' => 'cs.PL'));
 check_fails($f, ('archiveprefix' => 'arXiv', 'eprint' => '2111.13384', 'primaryclass' => 'hello'));


### PR DESCRIPTION
Closes #136.

Summary:
- Allow arXiv-specific `archiveprefix`, `eprint`, and `primaryclass` tags on `@article` entries.
- Keep `journal`, `volume`, and `number` mandatory for normal articles, but do not require them for arXiv article metadata.
- Tighten the arXiv checker so partial metadata and non-`arXiv` prefixes are rejected.

Validation:
- `perl -c bibcop.pl` -> syntax OK.
- `perl tests.pl` -> `GREAT! All tests are green.`
- `perlcritic --exclude=strict --exclude=require bibcop.pl tests.pl perl-tests/*.pl` -> all checked Perl sources OK.
- `xcop --quiet .` -> passed.
- `git diff --check` -> passed.
- `git diff --no-ext-diff | gitleaks stdin --no-banner --redact --exit-code 1` -> no leaks found.

Local limitation:
- `l3build ctan` was attempted, but this host TeX Live install has no `xelatex` format and stopped before generating `build/test/biblatex.log`. The repository GitHub workflow installs TeX Live from `DEPENDS.txt`, including `xetex`, before running the same target.