### PR TITLE
#111: allow parenthesized title prefixes

### DIFF
--- a/bibcop.pl
+++ b/bibcop.pl
@@ -341,7 +341,12 @@ sub check_typography {
     }
     foreach my $s (@need_space_after) {
       my $p = join('', @no_space_before);
-      if ($value =~ /^.*[^\\]\Q$s\E[^\}\s\Q$p\E].*$/) {
+      my $checked = $value;
+      if ($s eq ')' or $s eq ']') {
+        my $o = ($s eq ')') ? '(' : '[';
+        $checked =~ s/\Q$o\E[A-Z][A-Za-z]*\Q$s\E[A-Z][A-Za-z]*//g;
+      }
+      if ($checked =~ /^.*[^\\]\Q$s\E[^\}\s\Q$p\E].*$/) {
         return "In the '$tag', put a space after the $symbols{$s}"
       }
     }

--- a/perl-tests/checks.pl
+++ b/perl-tests/checks.pl
@@ -52,6 +52,7 @@ check_passes($f, ('title' => 'Proper formatting of (brackets)? with no space aft
 check_passes($f, ('title' => 'Proper formatting of (brackets): with no space after it'));
 check_passes($f, ('title' => 'Proper formatting of (brackets); with no space after it'));
 check_passes($f, ('title' => 'Proper spaces in \(\phi\) and in $\phi$'));
+check_passes($f, ('title' => '{In (Co)Inductive Type Theory}'));
 check_passes($f, ('publisher' => 'Elsevier Science Inc.'));
 check_passes($f, ('title' => 'Either You Love Me, or ... Not'));
 


### PR DESCRIPTION
Closes #111.

Summary:
- Allows title-case parenthesized prefixes such as `(Co)Inductive` to pass the typography spacing check.
- Adds a focused regression for the reported protected title.

Validation:
- `perl -c bibcop.pl` -> passed.
- `perl tests.pl` -> passed with `GREAT! All tests are green.`
- `perlcritic --exclude=strict --exclude=require bibcop.pl tests.pl perl-tests/*.pl` -> passed.
- `xcop --quiet .` -> passed.
- `git diff --check` -> passed.
- `git diff --no-ext-diff | gitleaks stdin --no-banner --redact --exit-code 1` -> no leaks found.

No secrets, credentials, live services, or production data were used.