### PR TITLE
#80: normalize double quotes in fixes

### DIFF
--- a/bibcop.pl
+++ b/bibcop.pl
@@ -728,6 +728,7 @@ sub fix_capitalization {
 sub fix_title {
   my ($value) = @_;
   $value = fix_capitalization($value);
+  $value = fix_quotes($value);
   $value =~ s/([^ ])---/$1 ---/g;
   $value =~ s/---([^ ])/--- $1/g;
   return $value;
@@ -824,6 +825,7 @@ sub fix_organization {
 
 sub fix_unicode {
   my ($value) = @_;
+  $value = fix_quotes($value);
   my %literals = (
     'ò' => '\`{o}', 'ó' => '\\\'{o}', 'ô' => '\^{o}', 'ö' => '\"{o}', 'ő' => '\H{o}', 'ǒ' => '\v{o}', 'õ' => '\~{o}',
     'à' => '\`{a}', 'á' => '\\\'{a}', 'â' => '\^{a}', 'ä' => '\"{a}', 'å' => '\r{a}', 'ą' => '\k{a}', 'ǎ' => '\v{a}', 'ã' => '\~{a}',
@@ -841,6 +843,14 @@ sub fix_unicode {
   while(my($k, $v) = each %literals) {
     $value =~ s/\Q$k\E/$v/g;
   }
+  return $value;
+}
+
+sub fix_quotes {
+  my ($value) = @_;
+  $value =~ s/“/``/g;
+  $value =~ s/”/''/g;
+  $value =~ s/(?<!\\)"([^"\n]+)(?<!\\)"/``$1''/g;
   return $value;
 }
 

--- a/perl-tests/fixing.pl
+++ b/perl-tests/fixing.pl
@@ -41,6 +41,9 @@ fixes('title', 'user\'s story', 'User\'s Story');
 fixes('title', 'step in, step out', 'Step in, Step Out');
 fixes('title', 'are we there yet?', 'Are We There yet?');
 fixes('title', 'GitHub Audience? --- a Thematic Analysis', 'GitHub Audience? --- A Thematic Analysis');
+fixes('title', '“Air Canada”', '``Air Canada\'\'');
+fixes('title', '"Air Canada"', '``Air Canada\'\'');
+fixes('title', 'A "Small" Example', 'A ``Small\'\' Example');
 
 fixes('booktitle', 'Proceedings Of IEEE Symposium On Art', 'Proceedings of Symposium on Art');
 fixes('booktitle', 'Symposium on Computers', 'Proceedings of the Symposium on Computers');


### PR DESCRIPTION
Closes #80.

## Summary
- Normalize smart double quotes in fixer output: `“Air Canada”` becomes ``Air Canada''.
- Normalize paired straight double quotes in fixer output: `"Air Canada"` becomes ``Air Canada''.
- Keep escaped TeX accent quotes such as `\"{o}` unchanged.
- Add regression coverage for title fixing with smart and straight double quotes.

## Validation
- `perl -c bibcop.pl` -> OK.
- `perl tests.pl` -> `GREAT! All tests are green.`
- `git diff --check` -> passed.
- `git diff --no-ext-diff | gitleaks stdin --no-banner --redact --exit-code 1` -> no leaks found.

Local limitation: this host does not currently have `perlcritic` or `xcop`; `brew install perl-critic` had no formula and a quick user-level `gem install xcop` attempt stalled, so those gates are left to GitHub Actions.

No secrets or credentials are included.
