### PR TITLE
#56: report unused bibitems

### DIFF
--- a/bibcop.pl
+++ b/bibcop.pl
@@ -966,6 +966,48 @@ sub entries {
   return @entries;
 }
 
+# Extract citation keys from a LaTeX .aux file.
+sub citations {
+  my ($aux) = @_;
+  my %cited;
+  while ($aux =~ /\\citation\{([^}]*)\}/g) {
+    remember_citations($1, \%cited);
+  }
+  while ($aux =~ /\\abx\@aux\@cite\{[^}]*\}\{([^}]*)\}/g) {
+    remember_citations($1, \%cited);
+  }
+  while ($aux =~ /\\abx\@aux\@segm\{[^}]*\}\{[^}]*\}\{([^}]*)\}/g) {
+    remember_citations($1, \%cited);
+  }
+  return %cited;
+}
+
+sub remember_citations {
+  my ($keys, $cited) = @_;
+  foreach my $key (split(/,/, $keys)) {
+    $key =~ s/^\s+|\s+$//g;
+    if ($key ne '') {
+      $cited->{$key} = 1;
+    }
+  }
+}
+
+sub cited_entries {
+  my ($file) = @_;
+  my %cited;
+  my $dir = dirname($file);
+  my $name = basename($file);
+  $name =~ s/\.[^.]+$/.aux/;
+  open(my $fh, '<', "$dir/$name") or return %cited;
+  my $aux; { local $/; $aux = <$fh>; }
+  close($fh);
+  my %found = citations($aux);
+  foreach my $key (keys %found) {
+    $cited{$key} = 1;
+  }
+  return %cited;
+}
+
 # Takes the text and returns only list of words seen there.
 sub only_words {
   my ($tex) = @_;
@@ -1134,6 +1176,9 @@ if (@ARGV+0 eq 0 or exists $args{'--help'} or exists $args{'-?'}) {
     debug((@entries+0) . ' entries found in ' . $file);
     my $found = 0;
     my %seen;
+    my %cited = cited_entries($file);
+    my $citations = keys %cited;
+    my $all = exists $cited{'*'};
     for my $i (0..(@entries+0 - 1)) {
       my %entry = %{ $entries[$i] };
       debug("Checking $entry{':name'} (no.$i)...");
@@ -1143,6 +1188,10 @@ if (@ARGV+0 eq 0 or exists $args{'--help'} or exists $args{'-?'}) {
         $found += 1;
       } elsif (defined $name) {
         $seen{$name} = 1;
+      }
+      if ($citations > 0 and not $all and defined $name and not exists $cited{$name}) {
+        warning("The entry '$name' is not cited");
+        $found += 1;
       }
       foreach my $err (process_entry(%entry)) {
         warning("$err, in the '$entry{':name'}' entry");

--- a/perl-tests/cli.pl
+++ b/perl-tests/cli.pl
@@ -21,6 +21,7 @@ assert_exec('--verbose README.md', 0, qr/\Q0 entries found in README.md\E/s);
 
 assert_exec('./test-files/duplicates.bib', 1, qr/\QThe entry 'knuth1974' is seen more than once\E/s);
 assert_exec('--latex ./test-files/duplicates.bib', 0, qr/\Q\PackageWarningNoLine{bibcop}{The entry 'knuth1974' is seen more than once\E/s);
+assert_exec('./test-files/unused.bib', 1, qr/\QThe entry 'unused' is not cited\E/s);
 
 assert_exec('missing-file.bib', 1, qr/\QCannot open file: missing-file.bib\E/s);
 assert_exec('--latex missing-file.bib', 0, qr/\Q\PackageError{bibcop}{Cannot open file: missing-file.bib}{}\E/s);

--- a/perl-tests/functions.pl
+++ b/perl-tests/functions.pl
@@ -15,4 +15,9 @@ assert_eq(clean_tex('{Alpha}'), 'Alpha');
 assert_eq(clean_tex('{{Beta}}'), 'Beta');
 assert_eq(clean_tex('Hello, {world!}'), 'Hello, {world!}');
 
+my %cited = citations('\citation{alpha, beta}
+\abx@aux@cite{0}{gamma}
+\abx@aux@segm{0}{0}{delta}');
+assert_eq(join(',', sort keys %cited), 'alpha,beta,delta,gamma');
+
 1;

--- a/test-files/unused.aux
+++ b/test-files/unused.aux
@@ -1,0 +1,6 @@
+% SPDX-FileCopyrightText: Copyright (c) 2022-2026 Yegor Bugayenko
+% SPDX-License-Identifier: MIT
+
+\relax
+\citation{used}
+\bibdata{unused}

--- a/test-files/unused.bib
+++ b/test-files/unused.bib
@@ -1,0 +1,16 @@
+% SPDX-FileCopyrightText: Copyright (c) 2022-2026 Yegor Bugayenko
+% SPDX-License-Identifier: MIT
+
+@book{used,
+  author = {Knuth},
+  title = {{TheTeXBook}},
+  year = {1984},
+  publisher = {ACM},
+}
+
+@book{unused,
+  author = {Dijkstra},
+  title = {{StructuredProgramming}},
+  year = {1972},
+  publisher = {ACM},
+}


### PR DESCRIPTION
Fixes #56

## Summary
- read the companion `.aux` file for the checked `.bib` file
- warn when a parsed BibTeX entry is absent from the collected citation keys
- cover standard BibTeX citations plus common BibLaTeX aux citation forms
- add a focused unused-entry CLI fixture

## Validation
- `perl -c bibcop.pl`
- `perl tests.pl`
- `perlcritic --exclude=strict --exclude=require bibcop.pl tests.pl perl-tests/*.pl`
- `xcop --quiet .`
- `git diff --check`
- `git diff --cached --check`
- `git diff --cached --no-ext-diff | gitleaks stdin --no-banner --redact --exit-code 1`

## Limitation
- `timeout 180s l3build ctan` was attempted locally, but this host cannot build the TeX integration suite because `xelatex.fmt` is unavailable and l3build then cannot open `build/test/biblatex.log`. The Perl-level change and focused CLI path are covered above.

No secrets in the diff.