### PR TITLE
Allow Unicode when curled brackets protect it

### DIFF
--- a/bibcop.dtx
+++ b/bibcop.dtx
@@ -388,7 +388,26 @@ booktitle = {{Proceedings of the International
 % \end{itemize}
 
 % \DescribeMacro{Unicode}
-% Non-ASCII characters are prohibited throughout the |.bib| file.
+% Non-ASCII characters are prohibited throughout the |.bib| file,
+% unless curled brackets protect them:
+%\iffalse
+%<*verb>
+%\fi
+\begin{verbatim}
+@book{proust1913,
+  author = {{Proust, Marcel}},
+  title = {{{À la Recherche du Temps Perdu}}},
+  publisher = {{Éditions Grasset}},
+}
+\end{verbatim}
+%\iffalse
+%</verb>
+%\fi
+% The brackets that delimit the value of a tag protect nothing,
+% which is why one extra pair is required around the text itself
+% (and yet one more around a |title|, since it demands its own pair anyway).
+% This is how a bibliography in Cyrillic, Greek, Arabic, or Chinese may be kept,
+% even though transliteration into Latin remains the safer choice.
 
 % \StopEventually{}
 

--- a/bibcop.pl
+++ b/bibcop.pl
@@ -374,7 +374,7 @@ sub check_type_capitalization {
   }
 }
 
-# Check that no values have non-ASCII symbols.
+# Check that no values have non-ASCII symbols outside of curled brackets.
 sub check_ascii {
   my (%entry) = @_;
   foreach my $tag (keys %entry) {
@@ -383,17 +383,17 @@ sub check_ascii {
     }
     my $value = $entry{$tag};
     for my $pos (0..length($value)-1) {
-      my $char = substr($value, $pos, 1);
-      my $ord = ord($char);
+      my $ord = ord(substr($value, $pos, 1));
       if ($ord == 9 || $ord == 10 || $ord == 13) {
         next;
       }
       if ($ord < 20) {
         return "In the '$tag', don't use control symbol '0x" . (sprintf '%04x', $ord) . "'"
       }
-      if ($ord > 0x7f) {
-        return "In the '$tag', don't use Unicode symbol '0x" . (sprintf '%04x', $ord) . "'"
-      }
+    }
+    my $naked = naked_unicode($value);
+    if ($naked > 0) {
+      return "In the '$tag', don't use Unicode symbol '0x" . (sprintf '%04x', $naked) . "' outside of curled brackets"
     }
   }
 }
@@ -616,6 +616,9 @@ sub entry_fix {
       $value = $fixer->($value);
     }
     $value = fix_unicode($value);
+    if (naked_unicode($value) > 0) {
+      $value = '{' . $value . '}';
+    }
     if ($tag =~ /title|booktitle|journal/) {
       $value = '{' . $value . '}';
     }
@@ -1060,6 +1063,33 @@ sub strip_outer_braces {
     return $inner;
   }
   return $s;
+}
+
+# Find the first non-ASCII symbol that curled brackets do not protect and return
+# its code. Return zero when every non-ASCII symbol is protected, or when there
+# are no such symbols at all. An escaped bracket protects nothing.
+sub naked_unicode {
+  my ($tex) = @_;
+  my $depth = 0;
+  my $escape = 0;
+  for my $pos (0..length($tex)-1) {
+    my $char = substr($tex, $pos, 1);
+    if ($escape) {
+      $escape = 0;
+    } elsif ($char eq '\\') {
+      $escape = 1;
+    } elsif ($char eq '{') {
+      $depth = $depth + 1;
+      next;
+    } elsif ($char eq '}') {
+      $depth = $depth - 1;
+      next;
+    }
+    if (ord($char) > 0x7f and $depth <= 0) {
+      return ord($char);
+    }
+  }
+  return 0;
 }
 
 # Take a TeX string and return a cleaner one, without redundant spaces, brackets, etc.

--- a/perl-tests/checking.pl
+++ b/perl-tests/checking.pl
@@ -86,6 +86,13 @@ passes((
   'note' => 'it is a blog post'
 ));
 passes((
+  ':type' => 'book',
+  'author' => '{Достоевский, Федор}',
+  'title' => '{{Бесы}}',
+  'year' => '1972',
+  'publisher' => '{Типография К. Замысловского}'
+));
+passes((
   ':type' => 'phdthesis',
   'author' => 'Doe, John',
   'title' => '{The Title}',

--- a/perl-tests/checks.pl
+++ b/perl-tests/checks.pl
@@ -11,6 +11,11 @@ my $f = 'check_ascii';
 check_passes($f, ('title' => "me \n and \r\t\n you"));
 check_fails($f, ('title' => 'hello'));
 check_fails($f, ('title' => 'привет'));
+check_fails($f, ('publisher' => 'Типография {К. Замысловского}'));
+check_fails($f, ('title' => '\{Бесы\}'));
+check_passes($f, ('title' => '{{Бесы}}'));
+check_passes($f, ('author' => '{Достоевский, Федор}'));
+check_passes($f, ('publisher' => 'The {Типография} Press'));
 
 $f = 'check_typography';
 check_fails($f, ('title' => 'A redundant space , before the comma'));

--- a/perl-tests/cli_fixing.pl
+++ b/perl-tests/cli_fixing.pl
@@ -10,6 +10,7 @@ use File::Temp qw/ tempfile /;
 
 assert_fix_compare('duplicates');
 assert_fix_compare('no-fixes');
+assert_fix_compare('unicode');
 
 sub read_file {
   my ($path) = @_;

--- a/perl-tests/entry_fixing.pl
+++ b/perl-tests/entry_fixing.pl
@@ -17,6 +17,9 @@ fixes_entry({':name' => 'k', ':type' => 'article', 'title' => 'Book', 'pages' =>
 my $today = strftime('%d-%m-%Y', localtime(time));
 fixes_entry({':name' => 'f', ':type' => 'misc', 'url' => 'http://google.com'}, "\@misc{f,\n  howpublished = {\\url{http://google.com}},\n  note = {[Online; accessed $today]},\n}\n\n");
 
+fixes_entry({':name' => 'd', ':type' => 'book', 'title' => '{{Бесы}}'}, "\@book{d,\n  title = {{{Бесы}}},\n}\n\n");
+fixes_entry({':name' => 'd', ':type' => 'book', 'author' => '{Достоевский, Федор}'}, "\@book{d,\n  author = {{Достоевский, Федор}},\n}\n\n");
+
 fixes_entry({':name' => 'f', ':type' => 'article', 'booktitle' => 'ONE'}, "\@article{f,\n  journal = {{ONE}},\n}\n\n");
 fixes_entry({':name' => 'f', ':type' => 'inproceedings', 'journal' => 'ONE'}, "\@inproceedings{f,\n  booktitle = {{Proceedings of the ONE}},\n}\n\n");
 

--- a/test-files/fixes/unicode/before.bib
+++ b/test-files/fixes/unicode/before.bib
@@ -1,0 +1,9 @@
+% SPDX-FileCopyrightText: Copyright (c) 2022-2026 Yegor Bugayenko
+% SPDX-License-Identifier: MIT
+
+@book{dostoyevsky1972besi,
+  author={{Достоевский, Федор}},
+  title={{{Бесы}}},
+  year={1972},
+  publisher={{Типография К. Замысловского}}
+}

--- a/test-files/fixes/unicode/expected.bib
+++ b/test-files/fixes/unicode/expected.bib
@@ -1,0 +1,9 @@
+% SPDX-FileCopyrightText: Copyright (c) 2022-2026 Yegor Bugayenko
+% SPDX-License-Identifier: MIT
+
+@book{dostoyevsky1972besi,
+  author = {{Достоевский, Федор}},
+  publisher = {{Типография К. Замысловского}},
+  title = {{{Бесы}}},
+  year = {1972},
+}


### PR DESCRIPTION
Non-ASCII text no longer fails outright. It passes the check when curled brackets wrap it, so this is fine now:

```
@book{dostoyevsky1972besi,
  author = {{Достоевский, Федор}},
  title = {{{Бесы}}},
  year = {1972},
  publisher = {{Типография К. Замысловского}},
}
```

Bare Unicode still fails, as before. The brackets around a tag value protect nothing, so an extra pair is required around the text itself — the same pair BibTeX wants anyway to keep the letters from being case-folded.

The `--fix` mode used to strip those brackets and print a file that its own check would then reject. It now puts them back whenever the value still carries non-ASCII symbols after transliteration, so a fixed file stays valid.

Tests cover the check, the fixer, and a full round trip through `--fix`. The manual gets an example with a French title, because the doc is typeset with pdfLaTeX and lmodern, which has no Cyrillic glyphs; teaching the preamble T2A would mean a new TeX dependency, so I left that alone.

Closes #141