### PR TITLE
Let curled brackets protect an entire title from the caps check

### DIFF
--- a/bibcop.dtx
+++ b/bibcop.dtx
@@ -203,6 +203,17 @@ title = {Structured Programming {with} Go {To} Statements}
 %\iffalse
 %</verb>
 %\fi
+% An entire value may be protected in the same manner, by one extra pair
+% of curly brackets around it (the pair that these three tags demand anyway does not count):
+%\iffalse
+%<*verb>
+%\fi
+\begin{verbatim}
+title = {{{lowercase title of a paper}}}
+\end{verbatim}
+%\iffalse
+%</verb>
+%\fi
 % This rule may be disabled by means of the |nocaps| package option.
 
 % \DescribeMacro{author}

--- a/bibcop.pl
+++ b/bibcop.pl
@@ -29,6 +29,10 @@ my %blessed = (
 # See https://research.arizona.edu/faq/what-do-you-mean-when-you-say-use-title-case-proposalproject-titles
 my %minors = map { $_ => 1 } qw/in of at to by the a an and or as if up via yet nor but off on for into vs versus/;
 
+# These tags bibcop wraps in curled brackets of its own, thus one more pair
+# of brackets around them is the protection made by the author.
+my %wrapped = map { $_ => 1 } qw/title booktitle journal/;
+
 # Check the presence of mandatory tags.
 sub check_mandatory_tags {
   if (exists $args{'--no:tags'}) {
@@ -80,8 +84,10 @@ sub check_capitalization {
       next;
     }
     my @ends = qw/ ; ? . --- : ! ` /;
-    my $value = $entry{$tag};
-    my @words = only_words($value);
+    if (protected($tag, $entry{$tag})) {
+      next;
+    }
+    my @words = only_words($entry{$tag});
     my $pos = 0;
     foreach my $word (@words) {
       $word =~ s/\.$//g;
@@ -609,17 +615,20 @@ sub entry_fix {
     if (not exists $allowed{$tag} and not exists $allowed{$tag . '?'}) {
       next;
     }
-    my $fixer = "fix_$tag";
-    my $fixed = $value;
-    if (defined &{$fixer}) {
-      no strict 'refs';
-      $value = $fixer->($value);
-    }
-    $value = fix_unicode($value);
-    if (naked_unicode($value) > 0) {
+    if (protected($tag, $entry{$tag})) {
       $value = '{' . $value . '}';
+    } else {
+      my $fixer = "fix_$tag";
+      if (defined &{$fixer}) {
+        no strict 'refs';
+        $value = $fixer->($value);
+      }
+      $value = fix_unicode($value);
+      if (naked_unicode($value) > 0) {
+        $value = '{' . $value . '}';
+      }
     }
-    if ($tag =~ /title|booktitle|journal/) {
+    if (exists $wrapped{$tag}) {
       $value = '{' . $value . '}';
     }
     if (not $value eq '') {
@@ -1063,6 +1072,17 @@ sub strip_outer_braces {
     return $inner;
   }
   return $s;
+}
+
+# Check whether curled brackets protect the entire value of the tag. The pair
+# of brackets that a tag demands on its own does not count as protection, since
+# it belongs to bibcop and not to the author.
+sub protected {
+  my ($tag, $value) = @_;
+  if (exists $wrapped{$tag}) {
+    $value = strip_outer_braces($value);
+  }
+  return strip_outer_braces($value) ne $value;
 }
 
 # Find the first non-ASCII symbol that curled brackets do not protect and return

--- a/perl-tests/checking.pl
+++ b/perl-tests/checking.pl
@@ -100,6 +100,15 @@ passes((
   'school' => 'Stanford'
 ));
 
+# capitalization is not checked inside extra curled brackets
+passes((
+  ':type' => 'phdthesis',
+  'author' => 'Doe, John',
+  'title' => '{{the title in lower case}}',
+  'year' => '1984',
+  'school' => 'Stanford'
+));
+
 sub fails {
   my (%entry) = @_;
   my @errors = process_entry(%entry);

--- a/perl-tests/checks.pl
+++ b/perl-tests/checks.pl
@@ -120,6 +120,10 @@ check_passes($f, ('booktitle' => '{Conferences ``On the Move\'\'}'));
 check_passes($f, ('booktitle' => '{Workshop on `On Demand\' Computing}'));
 check_passes($f, ('title' => 'A Study of ``In Context\'\' Learning'));
 check_fails($f, ('title' => '``in Context\'\' Learning'));
+check_passes($f, ('title' => '{{a b c}}'));
+check_passes($f, ('booktitle' => '{{the tex book}}'));
+check_passes($f, ('journal' => '{{a b c}}'));
+check_fails($f, ('title' => '{a b c}'));
 
 $f = 'check_howpublished';
 check_fails($f, ('howpublished' => 'hello'));

--- a/perl-tests/cli_fixing.pl
+++ b/perl-tests/cli_fixing.pl
@@ -11,6 +11,7 @@ use File::Temp qw/ tempfile /;
 assert_fix_compare('duplicates');
 assert_fix_compare('no-fixes');
 assert_fix_compare('unicode');
+assert_fix_compare('protected');
 
 sub read_file {
   my ($path) = @_;

--- a/perl-tests/functions.pl
+++ b/perl-tests/functions.pl
@@ -20,6 +20,16 @@ assert_eq(strip_outer_braces('{Alpha {Beta} Gamma}'), 'Alpha {Beta} Gamma');
 assert_eq(strip_outer_braces('{Alpha} and {Beta}'), '{Alpha} and {Beta}');
 assert_eq(strip_outer_braces('Alpha'), 'Alpha');
 
+assert_eq(protected('title', '{{Alpha}}'), 1);
+assert_eq(protected('booktitle', '{{Alpha Beta Gamma}}'), 1);
+assert_eq(protected('title', '{Alpha}'), '');
+assert_eq(protected('title', '{Alpha {Beta} Gamma}'), '');
+assert_eq(protected('journal', '{Alpha}'), '');
+assert_eq(protected('journal', '{{Alpha}}'), 1);
+assert_eq(protected('publisher', '{Alpha}'), 1);
+assert_eq(protected('publisher', 'Alpha'), '');
+assert_eq(protected('publisher', '{Alpha} and {Beta}'), '');
+
 my %cited = citations('\citation{alpha, beta}
 \abx@aux@cite{0}{gamma}
 \abx@aux@segm{0}{0}{delta}');

--- a/test-files/fixes/protected/before.bib
+++ b/test-files/fixes/protected/before.bib
@@ -1,0 +1,9 @@
+% SPDX-FileCopyrightText: Copyright (c) 2022-2026 Yegor Bugayenko
+% SPDX-License-Identifier: MIT
+
+@book{knuth1984,
+  author={Knuth, Donald},
+  title={{{the tex book}}},
+  year={1984},
+  publisher={{addison wesley}}
+}

--- a/test-files/fixes/protected/expected.bib
+++ b/test-files/fixes/protected/expected.bib
@@ -1,0 +1,9 @@
+% SPDX-FileCopyrightText: Copyright (c) 2022-2026 Yegor Bugayenko
+% SPDX-License-Identifier: MIT
+
+@book{knuth1984,
+  author = {Knuth, Donald},
+  publisher = {{addison wesley}},
+  title = {{{the tex book}}},
+  year = {1984},
+}


### PR DESCRIPTION
An extra pair of curled brackets around the whole value of a `title`, `booktitle`, or `journal` now switches the capitalization check off, exactly the way a pair around one word already did. The pair these three tags demand on their own does not count, so `title={{{a b c}}}` is quiet while `title={{a b c}}` is still checked. The `--fix` mode keeps the protecting brackets now, instead of throwing them away and re-capitalizing the text underneath.

Before this, `clean_tex()` peeled off every outer pair of brackets, so a title that the author had deliberately shielded looked no different from a plain one by the time the words reached the check. There was simply no way to opt a whole title out.

The new `protected()` sub decides this in one place and both the check and the fixer ask it, so they cannot drift apart. One thing worth a separate look: `clean_tex()` still strips outer brackets with a greedy regex, so a value like `{A} and {B}` comes out as `A} and {B` — `strip_outer_braces()` exists precisely to avoid that, and swapping it in there would be a small cleanup.

Closes #197