### PR TITLE
Keep brace-protected words whole in only_words

### DIFF
--- a/bibcop.pl
+++ b/bibcop.pl
@@ -1037,14 +1037,35 @@ sub cited_entries {
   return %cited;
 }
 
-# Takes the text and returns only list of words seen there.
+# Takes the text and returns only list of words seen there. Whatever curled
+# brackets protect stays inside its word, no matter how deeply the brackets
+# nest, so that 'Soci{\'e}t{\'e}' remains one word and not three.
 sub only_words {
   my ($tex) = @_;
-  my $t = clean_tex($tex);
-  $t =~ s/([^a-zA-Z0-9\\'])/ $1 /g;
+  my $t = '';
+  my $depth = 0;
+  my $escape = 0;
+  foreach my $char (split //, clean_tex($tex)) {
+    my $inside = $depth ne 0;
+    if ($escape) {
+      $escape = 0;
+    } elsif ($char eq '\\') {
+      $escape = 1;
+    } elsif ($char eq '{') {
+      $depth = $depth + 1;
+      $inside = 1;
+    } elsif ($char eq '}' and $depth > 0) {
+      $depth = $depth - 1;
+      $inside = 1;
+    }
+    if ($inside or $char =~ /[a-zA-Z0-9\\']/) {
+      $t .= $char;
+    } else {
+      $t .= " $char ";
+    }
+  }
   $t =~ s/- +- +-/---/g;
-  $t =~ s/{ /{/g;
-  $t =~ s/ }/}/g;
+  $t =~ s/^ +//;
   return split(/ +/, $t);
 }
 

--- a/perl-tests/checks.pl
+++ b/perl-tests/checks.pl
@@ -124,6 +124,8 @@ check_passes($f, ('title' => '{{a b c}}'));
 check_passes($f, ('booktitle' => '{{the tex book}}'));
 check_passes($f, ('journal' => '{{a b c}}'));
 check_fails($f, ('title' => '{a b c}'));
+check_passes($f, ('journal' => q(Annales {de} {la} {Soci{\'e}t{\'e}} Scientifique {de} Bruxelles)));
+check_passes($f, ('title' => q({\'E}tude of Numbers)));
 
 $f = 'check_howpublished';
 check_fails($f, ('howpublished' => 'hello'));

--- a/perl-tests/functions.pl
+++ b/perl-tests/functions.pl
@@ -15,6 +15,12 @@ assert_eq(clean_tex('{Alpha}'), 'Alpha');
 assert_eq(clean_tex('{{Beta}}'), 'Beta');
 assert_eq(clean_tex('Hello, {world!}'), 'Hello, {world!}');
 
+assert_eq(join('|', only_words('Hello, {GitHub.com} Users')), 'Hello|,|{GitHub.com}|Users');
+assert_eq(join('|', only_words(q(Soci{\'e}t{\'e} Scientifique))), q(Soci{\'e}t{\'e}|Scientifique));
+assert_eq(join('|', only_words(q(Annales {de} {Soci{\'e}t{\'e}} Scientifique))), q(Annales|{de}|{Soci{\'e}t{\'e}}|Scientifique));
+assert_eq(join('|', only_words('The {ACM}-ISCOPE Conference')), 'The|{ACM}|-|ISCOPE|Conference');
+assert_eq(join('|', only_words('No spaces around the---triple dash')), 'No|spaces|around|the|---|triple|dash');
+
 assert_eq(strip_outer_braces('{Alpha}'), 'Alpha');
 assert_eq(strip_outer_braces('{Alpha {Beta} Gamma}'), 'Alpha {Beta} Gamma');
 assert_eq(strip_outer_braces('{Alpha} and {Beta}'), '{Alpha} and {Beta}');


### PR DESCRIPTION
Words are now split only outside of curled brackets, at any nesting depth, so `{Soci{\'e}t{\'e}}` arrives at the checks as one word instead of five fragments.

The old `only_words()` spaced out every non-alphanumeric character and glued the brackets back only when they touched a word. A word with nested brackets fell apart, and the bare letter between two accents looked like a lower-cased major word, so `journal={Annales {de} {la} {Soci{\'e}t{\'e}} Scientifique {de} Bruxelles}` was reported as `the 6th word 't' is not` capitalized.

Output on the .bib files in `test-files/` is byte-for-byte the same as before, with and without `--fix`.

Closes #201